### PR TITLE
Adopt RPF v0.14.0 (raptrix-cim-arrow 0.7.0)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -16,4 +16,4 @@ Notes:
 
 - Hooks set via `core.hooksPath` are local to your clone and are not pushed to remotes; this protects developer privacy and allows each maintainer to opt in.
 - To bypass the hook for a single commit (advanced): `git commit --no-verify`.
-- If you want repository-enforced checks for all contributors, consider adding a CI check that rejects PRs containing secrets or proprietary formats.
+- If you want repository-enforced checks for all contributors, consider adding a CI check that rejects PRs containing secrets or licensed input formats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2026-08-16
+
+### RPF v0.14.0 (raptrix-cim-arrow 0.7.0) — additive MINOR
+
+- Bump to `raptrix-cim-arrow` **0.7.0** / RPF **v0.14.0**. No RAW/EPC semantic change.
+- `contingencies` uses the shared 10-column schema; `tpl_category` and `reserved` stay null (zero-row stub).
+- `contingency_sequences` is omitted (`include_contingency_sequences = false`).
+- Readers accept v0.14.0, v0.13.1, and v0.13.0. Pre-0.13 still requires re-export.
+- Dependency: git tag `v0.7.0`.
+
 ### Fixed
 
 - **Embedded apostrophes in PSS/E quoted fields**: `tokenize` no longer closes a quoted field on every `'`. A quote closes only when the next significant character is `,` or end-of-string; `''` remains an escaped apostrophe. Bus records such as `'O'Neil Bus 1'` now keep published VM/VA/BASKV instead of collapsing to a flat seed. Regenerate affected local goldens after upgrading.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@
 
 [package]
 name = "raptrix-psse-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Raptrix PowerFlow <dev@raptrix.com>"]
 license = "MPL-2.0"
-description = "High-performance PSS/E (.raw + .dyr) -> Raptrix PowerFlow Interchange v0.13.0 converter"
+description = "High-performance PSS/E (.raw + .dyr) -> Raptrix PowerFlow Interchange v0.14.0 converter"
 repository = "https://github.com/RaptrixPowerFlow/raptrix-psse-rs"
 keywords = ["psse", "power-systems", "converter", "raptrix", "cim"]
 categories = ["command-line-utilities", "parser-implementations"]
@@ -34,10 +34,9 @@ clap = { version = "4", features = ["derive"] }
 # The canonical source is the IEC 61970 CIM implementation at GitHub;
 # depend on the public repository instead of a local path.
 #
-# NOTE: For local development against an unpublished `raptrix-cim-arrow` checkout,
-# add a `[patch]` table in `.cargo/config.toml` (do not commit) or temporarily patch
-# `Cargo.toml` locally — CI and fresh clones resolve only the git tag above.
-raptrix-cim-arrow = { git = "https://github.com/RaptrixPowerFlow/raptrix-cim-rs", tag = "v0.6.0" }
+# Local sibling override belongs in .cargo/config.toml (gitignored).
+# CI and fresh clones resolve only the git tag below.
+raptrix-cim-arrow = { git = "https://github.com/RaptrixPowerFlow/raptrix-cim-rs", tag = "v0.7.0" }
 
 [dev-dependencies]
 # Golden-file integration tests depend on the raptrix-cim-arrow reader.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,25 @@ Copyright (c) 2026 Raptrix PowerFlow
 
 ### Unreleased: golden corpus prefers dynamic
 
-When a `.dyr` / `.dyn` companion exists, `tests/golden/<stem>.rpf` is the **dynamic** conversion. `_dynamic.rpf` is an alias; `_static.rpf` is the no-DYR A/B twin. Downstream (raptrix-core) indexes prefer `_dynamic` over plain over `_static`. Regenerate with `cargo test --release --test golden_test`.
+When a `.dyr` / `.dyn` companion exists, `tests/golden/<stem>.rpf` is the **dynamic** conversion. `_dynamic.rpf` is an alias; `_static.rpf` is the no-DYR A/B twin. Downstream solver / RPF consumer indexes prefer `_dynamic` over plain over `_static`. Regenerate with `cargo test --release --test golden_test`.
+
+### raptrix-psse-rs **v0.7.0**: RPF **v0.14.0** (`raptrix-cim-arrow` **0.7.0**) — **Additive MINOR (dual-read v0.13.1 / v0.13.0)**
+
+`raptrix-psse-rs` **v0.7.0** emits RPF **v0.14.0**.
+
+#### What changed
+
+- Writer stamps `v0.14.0`; `SUPPORTED_RPF_VERSIONS` accepts **v0.14.0**, **v0.13.1**, and **v0.13.0**.
+- **No re-export required** for existing v0.13.x `.rpf` files.
+- No RAW semantic change. `contingencies` is still a zero-row stub on the shared 10-column schema; `tpl_category` and `reserved` stay null. `contingency_sequences` is omitted.
+- PSS/E path still omits `computational_load_profiles` and writes `computational_load_mode = null` (optional CLP columns stay null/absent).
+- **Dependency**: `raptrix-cim-arrow` **0.7.0** / git tag **`v0.7.0`**.
+
+#### Consumer checklist
+
+1. Accept `raptrix.version` ∈ {`v0.14.0`, `v0.13.1`, `v0.13.0`} (and bare `0.14.0` / `0.13.x` aliases).
+2. Treat `contingencies.tpl_category` / `reserved` as nullable when present; ignore when absent.
+3. Do not require a `contingency_sequences` table on PSS/E exports.
 
 ### raptrix-psse-rs **v0.6.0**: RPF **v0.13.0** (`raptrix-cim-arrow` **0.6.0**) — **Breaking clean cut (re-export required)**
 
@@ -32,7 +50,7 @@ When a `.dyr` / `.dyn` companion exists, `tests/golden/<stem>.rpf` is the **dyna
 - `buses.type` dictionary tokens `PQ`/`PV`/`Slack`; `controlled_bus_id` **null** = local regulation (do not write `0`).
 - Native UTC timestamps; optional load/shunt `mrid`; dynamics `classical_params` when DYR supplies H/D/xd'/mbase.
 - Root metadata stamps `rpf.identity.model=hybrid_solver_flat_v1`.
-- **`baseline_source_case_id`** replaces any prior `original_sentinel_case_id` wire name (null on standard PSS/E planning exports).
+- **`baseline_source_case_id`** replaces the prior `original_sentinel_case_id` wire name (null on standard PSS/E planning exports).
 - **Reader compatibility**: only v0.13.0 / `0.13.0`. **Re-export all goldens and case libraries.** No upgrade CLI for old `.rpf` files.
 - **Dependency**: `raptrix-cim-arrow` **0.6.0** / git tag **`v0.6.0`**.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The converter is built for modern 2026+ studies while preserving strong legacy P
 - Prefer explicit modern-grid representations over lossy legacy flattening.
 - Use DYR model families as the primary source for IBR classification and controls.
 - Fall back to RAW WMOD where DYR is unavailable.
-- Always emit the **18** canonical required root tables for **RPF v0.13.0** (zero-row where applicable) so downstream pipelines stay deterministic.
+- Always emit the **18** canonical required root tables for **RPF v0.14.0** (zero-row where applicable) so downstream solver / RPF consumer pipelines stay deterministic.
 
 ## CLI Reference
 
@@ -74,9 +74,9 @@ cargo run --bin branch_deck_scan -- --raw <FILE.raw> [--rpf <FILE.rpf>] [--list-
 
 Diagnostics for the PSS/E BRANCH section: raw `ST` token histogram, parsed vs rejected lines, in-service/out-of-service counts, optional duplicate `(from_bus,to_bus,ckt)` keys, and (with `--rpf`) an in-service multiset diff between the parsed RAW network and the RPF `branches` table. Use this when reconciling branch row counts against tools that omit `ST=0` lines.
 
-## RPF v0.13.0 coverage
+## RPF v0.14.0 coverage
 
-The converter emits the **18** required root tables from the locked **v0.13.0** contract (see [raptrix-cim-rs schema-contract](https://github.com/RaptrixPowerFlow/raptrix-cim-rs/blob/main/docs/schema-contract.md)), including:
+The converter emits the **18** required root tables from the locked **v0.14.0** contract (dual-read v0.13.1 / v0.13.0; see [raptrix-cim-rs schema-contract](https://github.com/RaptrixPowerFlow/raptrix-cim-rs/blob/main/docs/schema-contract.md)), including:
 
 - metadata
 - buses
@@ -128,11 +128,11 @@ The optional **`scenario_context`** root table is **not** written by default. Th
 
 For schema v0.9.3 onward, nominal-kV fields are required on `branches`, `transformers_2w`, and `transformers_3w`. Export uses RAW nominal values when present and falls back to connected bus nominal-kV; if no valid value can be resolved, conversion fails fast.
 
-## Recent release (v0.6.0)
+## Recent release (v0.7.0)
 
-- **RPF v0.13.0** (`raptrix.version` / `raptrix-cim-arrow` **0.6.0**): clean-cut contract — **re-export required** for all pre-0.13 `.rpf` files (no dual-read of v0.12.x).
-- Provenance, dictionary bus types, nullable local `controlled_bus_id`, native UTC timestamps, optional load/shunt `mrid`, and `classical_params` on dynamics when available.
-- **`raptrix-cim-arrow`** is pinned to git tag **`v0.6.0`**. For a sibling `raptrix-cim-rs` checkout, use a **local** `[patch]` in `.cargo/config.toml` (not committed) so CI and fresh clones keep building from GitHub.
+- **RPF v0.14.0** (`raptrix.version` / `raptrix-cim-arrow` **0.7.0**): additive MINOR; dual-read **v0.13.1** and **v0.13.0**. Pre-0.13 still requires re-export.
+- No RAW semantic change. `contingencies` remains a zero-row stub (`tpl_category` / `reserved` null). `contingency_sequences` is omitted.
+- **`raptrix-cim-arrow`** is pinned to git tag **`v0.7.0`**. For a sibling `raptrix-cim-rs` checkout, use a **local** `[patch]` in `.cargo/config.toml` (not committed) so CI and fresh clones keep building from GitHub.
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history and [MIGRATION.md](MIGRATION.md) for schema version notes.
 
@@ -175,7 +175,7 @@ Place any confidential or licensed PSS/E input files under `tests/data/external/
 cargo test --release -- --nocapture
 ```
 
-The **`golden_test`** integration suite (`tests/golden_test.rs`) converts every file in that corpus to **v0.13.0** `.rpf` under `tests/golden/`. **Dynamic is canonical**: when a `.dyr` / `.dyn` companion exists it is attached to `<stem>.rpf` (and mirrored as `<stem>_dynamic.rpf`); a no-DYR `<stem>_static.rpf` is also written for A/B. Cases without a dynamics deck are static-only.
+The **`golden_test`** integration suite (`tests/golden_test.rs`) converts every file in that corpus to **v0.14.0** `.rpf` under `tests/golden/`. **Dynamic is canonical**: when a `.dyr` / `.dyn` companion exists it is attached to `<stem>.rpf` (and mirrored as `<stem>_dynamic.rpf`); a no-DYR `<stem>_static.rpf` is also written for A/B. Cases without a dynamics deck are static-only.
 
 ### Windows, OneDrive, and WSL
 
@@ -213,7 +213,7 @@ End-to-end timings are **parse RAW (+ optional DYR) + build Arrow tables + write
 | IEEE 118-bus | static | ~28 ms |
 | Texas2k (2.7k buses) | static | ~45 ms |
 | Texas2k (2.7k buses) | + DYR | ~190 ms |
-| NYISO ~1.5k-bus snapshots | static | ~70–85 ms |
+| ~1.5k-bus snapshots | static | ~70–85 ms |
 | Texas7k (~6.7k buses) | static | ~170 ms |
 | Texas7k 2030 | static | ~190 ms |
 | Texas7k | + DYR | ~210 ms |
@@ -221,7 +221,7 @@ End-to-end timings are **parse RAW (+ optional DYR) + build Arrow tables + write
 | ACTIVSg25k | static | ~410 ms |
 | Midwest24k | static | ~490 ms |
 | ACTIVSg70k | static | ~990 ms |
-| Eastern Interconnect 515GW | static | ~1.1 s |
+| 515GW interconnect research case | static | ~1.1 s |
 
 These are **local engineering reference numbers**, not vendor benchmarks. Use them to spot regressions between commits; re-run `cargo test --release --test golden_test -- --nocapture` or `./scripts/verify-external-golden.sh` on your host to refresh.
 
@@ -238,7 +238,7 @@ Golden tests (with local external inputs) help catch regressions; they are not a
 
 ## Versioning & Schema Contract
 
-This crate is pinned to **`raptrix-cim-arrow` 0.6.0** (git tag `v0.6.0`). Every emitted `.rpf` is validated against the locked **v0.13.0** contract before returning. Readers accept **only** v0.13.0 — re-export all older `.rpf` files through this converter.
+This crate is pinned to **`raptrix-cim-arrow` 0.7.0** (RPF **v0.14.0**). Every emitted `.rpf` is validated against the locked contract before returning. Readers accept **v0.14.0, v0.13.1, and v0.13.0** — re-export only pre-0.13 `.rpf` files through this converter.
 
 See [raptrix-cim-rs schema-contract](https://github.com/RaptrixPowerFlow/raptrix-cim-rs/blob/main/docs/schema-contract.md) for the full RPF specification.
 

--- a/docs/psse-mapping.md
+++ b/docs/psse-mapping.md
@@ -13,7 +13,7 @@
 Copyright (c) 2026 Raptrix PowerFlow
 
 This document provides the field-by-field rules for translating PSS/E RAW (v23–v35)
-and DYR records into the Raptrix PowerFlow Interchange (`.rpf` / RPF **v0.13.0**) Apache
+and DYR records into the Raptrix PowerFlow Interchange (`.rpf` / RPF **v0.14.0**) Apache
 Arrow schema.
 
 **Scope:** Describes **current** export behavior for this crate revision. It is **not** a commitment that every omitted PSS/E field will gain a dedicated column, or that partial sections will be completed in any particular order—those follow interchange and product releases independently.
@@ -33,11 +33,11 @@ Arrow schema.
 | v23 – v34 | ✓ | v33 is the most common; treated as baseline layout. |
 | v35 | ✓ | Extra fields (branch NAME, generator NREG/BASLOD, switched-shunt NAME/NREG) detected via `VersionOffsets` struct. |
 
-### v0.13.0 contract (current)
+### v0.14.0 contract (current)
 
 - **18** required root tables (see `raptrix-cim-rs` `docs/schema-contract.md`). **`ibr_devices` is removed**; inverter-based resources are modeled only on **`generators`** (`is_ibr`, `ibr_subtype`).
-- **Clean cut**: writers emit **only** v0.13.0; readers accept **only** v0.13.0 / `0.13.0`. Re-export all pre-0.13 `.rpf` files.
-- Optional root tables **`remedial_action_schemes`** and **`contingency_island_analysis`** are **not** emitted by this PSS/E converter (no RAW mapping today).
+- **Emit v0.14.0**; readers accept **v0.14.0**, **v0.13.1**, and **v0.13.0**. Pre-0.13 `.rpf` files remain rejected (re-export required).
+- Optional root tables **`remedial_action_schemes`**, **`contingency_island_analysis`**, and **`contingency_sequences`** are **not** emitted by this PSS/E converter (no RAW mapping today). `contingencies` is a zero-row stub on the shared 10-column schema (`tpl_category` / `reserved` null).
 - `loads` includes additive ZIP fidelity columns in v0.9.1+: `p_i_pu`, `q_i_pu`, `p_y_pu`, `q_y_pu`, plus trailing nullable **`mrid`** (null from PSS/E).
 - Required tables include `multi_section_lines`, `dc_lines_2w`, and `switched_shunt_banks`.
 - `branches` includes nullable linkage fields `parent_line_id` and `section_index`.
@@ -51,7 +51,7 @@ Arrow schema.
   - `modern_grid_profile`, `ibr_penetration_pct`, `has_ibr`, `has_smart_valve`, `has_multi_terminal_dc`, `study_purpose`, `scenario_tags`
   - `hour_ahead_uncertainty_band`, `commitment_source`, `solver_q_limit_infeasible_count`, `pv_to_pq_switch_count`, `real_time_discovery`
   - **`default_shunt_control_mode`** (nullable Dictionary): for typical **planning** exports this converter sets **`planning_full`** when `case_mode` is `flat_start_planning`, `warm_start_planning`, or `hour_ahead_advisory`; optional file-level IPC key **`rpf.default_shunt_control_mode`** mirrors the same string when set.
-  - **`computational_load_mode`** (v0.10.0+, nullable Boolean): always **null** for standard PSS/E exports from this crate; the optional **`computational_load_profiles`** root table is **not** emitted here.
+  - **`computational_load_mode`** (v0.10.0+, nullable Boolean): always **null** for standard PSS/E exports from this crate; the optional **`computational_load_profiles`** root table is **not** emitted here (optional CLP columns therefore absent / would be null if authored elsewhere).
 - Root metadata stamps **`rpf.identity.model=hybrid_solver_flat_v1`**.
 - **`dynamics_models.perc1_params`** (nullable struct): all **null** until PERC1 parameters are mapped from DYR.
 - **`dynamics_models.classical_params`** (v0.13.0+, nullable struct `{H,D,xd_prime,mbase_mva}`): populated when DYR params supply classical first-swing fields.
@@ -386,7 +386,7 @@ input deck.
 | DYR record field | Rust field | RPF column | Notes |
 |---|---|---|---|
 | Bus number | `DyrModelData.bus_id` | `bus_id` | Model attachment bus. |
-| Machine / device ID | `DyrModelData.id` | `gen_id` | Preserved as the PSS/E ID token; for machine-linked models this matches `generators.id`. |
+| Machine / device ID | `DyrModelData.id` | `gen_id` | Preserved as the PSS/E ID token; machine-linked models join via `generators.mrid` / `generators.generator_id` (there is no `generators.id`). |
 | Model name | `DyrModelData.model` | `model_type` | Examples: `"GENROU"`, `"ESST4B"`, `"GGOV1"`, `"PSS2A"`, `"REGCA1"`. |
 | Parameter 1..N | `DyrModelData.params` | `params["p1"]` ... `params["pN"]` | Numeric parameters are written in source order using 1-based keys. |
 | — | — | `perc1_params` | **v0.10.0+**: nullable struct column required by the interchange contract. This exporter writes **null** on every row until PERC1 parameters are mapped from DYR. |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // https://mozilla.org/MPL/2.0/.
 
 //! `raptrix-psse-rs` — High-performance PSS/E (`.raw` + `.dyr`) →
-//! Raptrix PowerFlow Interchange v0.13.0 converter.
+//! Raptrix PowerFlow Interchange v0.14.0 converter.
 //!
 //! # Crate layout
 //! * [`models`] — PSS/E data structures.
@@ -362,6 +362,7 @@ pub fn write_psse_to_rpf_with_options(
         contingencies_are_stub: true,
         dynamics_are_stub: network.dyr_models.is_empty(),
         include_solved_state: emit_warm_start_seed,
+        include_contingency_sequences: false,
         ..RootWriteOptions::default()
     };
     let mut additional_root_metadata = HashMap::new();
@@ -409,7 +410,7 @@ pub fn write_psse_to_rpf_with_options(
     );
 
     // `write_root_rpf_with_metadata` stamps `raptrix.version` from `raptrix-cim-arrow`
-    // (`SCHEMA_VERSION`, currently v0.13.0) and re-opens the file for `validate_rpf_file`
+    // (`SCHEMA_VERSION`, currently v0.14.0) and re-opens the file for `validate_rpf_file`
     // so every emitted `.rpf` matches the locked root contract before returning.
     write_root_rpf_with_metadata(
         output,
@@ -3527,8 +3528,7 @@ fn build_dynamics_models_batch(records: &[models::DyrModelData]) -> Result<Recor
                 .map(|(_, v)| *v)
                 .filter(|v| v.is_finite())
         };
-        let mach =
-            machine_classical.get(&(rec.bus_id, rec.id.to_string(), rec.model.to_string()));
+        let mach = machine_classical.get(&(rec.bus_id, rec.id.to_string(), rec.model.to_string()));
         let h = mach
             .map(|m| m.h)
             .filter(|v| v.is_finite() && *v > 0.0)

--- a/tests/golden_test.rs
+++ b/tests/golden_test.rs
@@ -144,17 +144,12 @@ fn run_case(
 
     if dyn_s.is_some() {
         let dyn_alias = golden_dir.join(format!("{case_name}_dynamic.rpf"));
-        fs::copy(&out_s, &dyn_alias).map_err(|e| {
-            format!(
-                "failed to write dynamic alias {}: {e}",
-                dyn_alias.display()
-            )
-        })?;
+        fs::copy(&out_s, &dyn_alias)
+            .map_err(|e| format!("failed to write dynamic alias {}: {e}", dyn_alias.display()))?;
         let static_out = golden_dir.join(format!("{case_name}_static.rpf"));
         let static_s = static_out.to_string_lossy().to_string();
-        raptrix_psse_rs::write_psse_to_rpf(&raw_s, None, &static_s).map_err(|e| {
-            format!("static companion conversion failed for {case_name}: {e:#}")
-        })?;
+        raptrix_psse_rs::write_psse_to_rpf(&raw_s, None, &static_s)
+            .map_err(|e| format!("static companion conversion failed for {case_name}: {e:#}"))?;
     } else {
         // No DYR — keep a `_static` alias for scripts that still look for that suffix.
         let static_alias = golden_dir.join(format!("{case_name}_static.rpf"));
@@ -217,7 +212,7 @@ fn run_case(
 
 #[test]
 fn golden_build_all_external_raw_cases() {
-    assert_eq!(RPF_VERSION, "v0.13.0");
+    assert_eq!(RPF_VERSION, "v0.14.0");
 
     let external_dir = Path::new(EXTERNAL_DIR);
     if !external_dir.exists() {
@@ -337,7 +332,10 @@ fn golden_build_all_external_raw_cases() {
             "Texas2k_series24_gfm_dynamic.rpf",
         ),
         ("Texas7k_2030_20220923.rpf", "Texas7k_2030.rpf"),
-        ("Texas7k_2030_20220923_static.rpf", "Texas7k_2030_static.rpf"),
+        (
+            "Texas7k_2030_20220923_static.rpf",
+            "Texas7k_2030_static.rpf",
+        ),
         ("Midwest24k_20220923.rpf", "Midwest24k.rpf"),
         ("Midwest24k_20220923_static.rpf", "Midwest24k_static.rpf"),
     ];

--- a/tests/rpf_contract_smoke_test.rs
+++ b/tests/rpf_contract_smoke_test.rs
@@ -24,8 +24,8 @@ use raptrix_cim_arrow::{
     BUS_TYPE_PQ, BUS_TYPE_PV, BUS_TYPE_SLACK, IDENTITY_MODEL_HYBRID_SOLVER_FLAT_V1,
     METADATA_KEY_CASE_MODE, METADATA_KEY_DEFAULT_SHUNT_CONTROL_MODE, METADATA_KEY_IDENTITY_MODEL,
     METADATA_KEY_MRID_SUPPORT, RPF_VERSION, RootWriteOptions, TABLE_BRANCHES, TABLE_BUSES,
-    TABLE_GENERATORS, TABLE_LOADS, TABLE_METADATA, TABLE_OWNERS, read_rpf_tables,
-    rpf_file_metadata,
+    TABLE_CONTINGENCIES, TABLE_CONTINGENCY_SEQUENCES, TABLE_GENERATORS, TABLE_LOADS,
+    TABLE_METADATA, TABLE_OWNERS, read_rpf_tables, rpf_file_metadata,
 };
 
 fn dict_utf8_at(col: &dyn Array, i: usize) -> &str {
@@ -921,7 +921,7 @@ DISCONNECTED SLACK
 /// seed `v_mag_pu`. For PV/Slack buses, our writer sets `v_mag_set = gen.vs`
 /// (the scheduled target), but `bus.vm` (the operating value) differs by the
 /// machine's reactive trim. Letting the importer overwrite the target with
-/// the operating value measurably regresses convergence on Texas7k / NYISO
+/// the operating value measurably regresses convergence on Texas7k / 1.5k-bus snapshots
 /// planning files. The seed is emitted again only by callers that genuinely
 /// carry a separately-computed warm-start payload.
 #[test]
@@ -1267,14 +1267,14 @@ BUS TYPE
     )
     .expect("conversion should succeed");
 
-    assert_eq!(RPF_VERSION, "v0.13.0");
+    assert_eq!(RPF_VERSION, "v0.14.0");
     let metadata = rpf_file_metadata(&out_path).expect("rpf_file_metadata");
     assert_eq!(
         metadata
             .get("rpf_version")
             .map(|v| v.as_str())
             .unwrap_or(""),
-        "v0.13.0"
+        RPF_VERSION
     );
     assert_eq!(
         metadata
@@ -1326,6 +1326,21 @@ BUS TYPE
     );
     assert_eq!(branch_mrid.value(0), "BR_1_2_1");
     assert_eq!(gen_mrid.value(0), "GEN_1_1");
+
+    let (_, contingencies) = tables
+        .iter()
+        .find(|(name, _)| name == TABLE_CONTINGENCIES)
+        .expect("contingencies table");
+    assert_eq!(contingencies.schema().fields().len(), 10);
+    assert_eq!(contingencies.schema().field(8).name(), "tpl_category");
+    assert_eq!(contingencies.schema().field(9).name(), "reserved");
+    assert_eq!(contingencies.num_rows(), 0);
+    assert!(
+        tables
+            .iter()
+            .all(|(name, _)| name != TABLE_CONTINGENCY_SEQUENCES),
+        "PSS/E path must omit contingency_sequences"
+    );
 
     let _ = fs::remove_file(raw_path);
     let _ = fs::remove_file(out_path);


### PR DESCRIPTION
## Summary
- Bump crate to 0.7.0 and pin raptrix-cim-arrow to git tag v0.7.0 (RPF v0.14.0).
- Writers stamp v0.14.0. Contingencies stay a zero-row 10-col stub; contingency_sequences omitted.
- No RAW semantic change. Local goldens regenerated (gitignored). Public docs sanitized.

## Test plan
- [x] sync-versions.ps1 -Check
- [x] cargo test --workspace --all-targets
- [ ] CI green

Made with [Cursor](https://cursor.com)